### PR TITLE
re2:replace changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+Contributing to re2
+-------------------
+
+Before implementing a new feature, please submit a ticket to discuss your plans.  
+The feature might have been rejected already, or the implementation might already be decided.
+
+Code style
+----------
+
+The following rules must be followed:
+ * Do not introduce trailing whitespace
+ * Do not mix spaces and tabs
+ * Do not introduce lines longer than 80 characters
+
+The following rules should be followed:
+ * Write small functions whenever possible
+ * Avoid having too many clauses containing clauses containing clauses.  
+   Basically, avoid deeply nested functions.
+
+[erlang-mode (emacs)](http://www.erlang.org/doc/man/erlang.el.html)
+indentation is preferred. This will keep the code base consistent.  
+vi users are encouraged to give [Vim emulation](http://emacswiki.org/emacs/Evil) ([more
+info](https://gitorious.org/evil/pages/Home)) a try.
+
+Pull requests and branching
+---------------------------
+
+Use one topic branch per pull request. If you do that, you can add extra commits or fix up  
+buggy commits via `git rebase -i`, and update the branch. The updated branch will be  
+visible in the same pull request. Therefore, you should not open a new pull request when  
+you have to fix your changes.
+
+Do not commit to master in your fork.
+
+Provide a clean branch without merge commits.
+
+Committing your changes
+-----------------------
+
+Please ensure that all commits pass all tests, and do not have extra Dialyzer warnings.  
+To do that run `make check`.
+
+#### Structuring your commits
+
+Fixing a bug is one commit.  
+Adding a feature is one commit.  
+Adding two features is two commits.  
+Two unrelated changes is two commits.
+
+If you fix a (buggy) commit, squash (`git rebase -i`) the changes as a fixup commit into  
+the original commit.
+
+#### Writing Commit Messages
+
+It's important to write a proper commit title and description. The commit title must be  
+at most 50 characters; it is the first line of the commit text. The second line of the  
+commit text must be left blank. The third line and beyond is the commit message. You  
+should write a commit message. If you do, wrap all lines at 72 characters. You should  
+explain what the commit does, what references you used, and any other information  
+that helps understanding your changes.
+
+Basically, structure your commit message like this:
+
+<pre>
+One line summary (at most 50 characters)
+
+Longer description (wrap at 72 characters)
+</pre>
+
+##### Commit title/summary
+
+* At most 50 characters
+* What was changed
+* Imperative present tense (Fix, Add, Change)
+ * `Fix bug 123`
+ * `Add 'foobar' command`
+ * `Change default timeout to 123`
+* No period
+
+##### Commit description
+
+* Wrap at 72 characters
+* Why, explain intention and implementation approach
+* Present tense

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2011 Tuncer Ayaz
+Copyright (c) 2010-2014 Tuncer Ayaz
 
 All rights reserved.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean doc test dialyzer check
 
-REBAR=@`sh -c "PATH='$(PATH)':support which rebar\
-	||support/getrebar||echo false"`
+REBAR:=$(shell sh -c "PATH='$(PATH)':support which rebar\
+	||support/getrebar||echo false")
 
 all:
 	$(REBAR) compile eunit
@@ -13,9 +13,9 @@ clean:
 	$(REBAR) clean
 
 test:
-	$(REBAR) eunit
+	ERL_LIBS=$(CURDIR) $(REBAR) eunit
 
 dialyzer:
-	dialyzer -n -nn ebin
+	ERL_LIBS=$(CURDIR) dialyzer -n -nn ebin
 
 check: test dialyzer

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean doc test
+.PHONY: all clean doc test dialyzer check
 
 REBAR=@`sh -c "PATH='$(PATH)':support which rebar\
 	||support/getrebar||echo false"`
@@ -14,3 +14,8 @@ clean:
 
 test:
 	$(REBAR) eunit
+
+dialyzer:
+	dialyzer -n -nn ebin
+
+check: test dialyzer

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **re2** is built with [rebar](http://bitbucket.org/basho/rebar/) and
 we do expect `rebar` to be in the search `PATH`.  
-If `rebar` can not be found in the search `PATH` it will be  
+If `rebar` can not be found in the search `PATH`, it will be  
 automatically downloaded to `support/rebar` for local usage.
 
 ### To build and run eunit tests execute

--- a/THANKS
+++ b/THANKS
@@ -1,0 +1,6 @@
+The following people have contributed to re2:
+
+Tuncer Ayaz
+Anthony Molinaro
+Kenji Rikitake
+David Hull

--- a/c_src/re2_nif.cpp
+++ b/c_src/re2_nif.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2011 Tuncer Ayaz. All Rights Reserved.
+// Copyright 2010-2014 Tuncer Ayaz. All Rights Reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/c_src/re2_nif.cpp
+++ b/c_src/re2_nif.cpp
@@ -507,20 +507,27 @@ static ERL_NIF_TERM re2_replace(ErlNifEnv* env, int argc,
         if (argc == 4 && !parse_replace_options(env, argv[3], opts))
             return enif_make_badarg(env);
 
-        if (opts.global && re2::RE2::GlobalReplace(&s, *(&re), r))
-        {
-            return rres(env, s);
-        }
-        else if (re2::RE2::Replace(&s, *(&re), r))
-        {
-            return rres(env, s);
+        if (opts.global) {
+            if (re2::RE2::GlobalReplace(&s, *(&re), r))
+            {
+                return rres(env, s);
+            }
+            else
+            {
+                return a_error;
+            }
         }
         else
         {
-            return a_error;
+            if (re2::RE2::Replace(&s, *(&re), r))
+            {
+                return rres(env, s);
+            }
+            else
+            {
+                return a_error;
+            }
         }
-
-        return enif_make_badarg(env);
     }
     else
     {

--- a/c_src/re2_nif.cpp
+++ b/c_src/re2_nif.cpp
@@ -508,26 +508,13 @@ static ERL_NIF_TERM re2_replace(ErlNifEnv* env, int argc,
             return enif_make_badarg(env);
 
         if (opts.global) {
-            if (re2::RE2::GlobalReplace(&s, *(&re), r))
-            {
-                return rres(env, s);
-            }
-            else
-            {
-                return a_error;
-            }
+            (void) re2::RE2::GlobalReplace(&s, *(&re), r);
         }
         else
         {
-            if (re2::RE2::Replace(&s, *(&re), r))
-            {
-                return rres(env, s);
-            }
-            else
-            {
-                return a_error;
-            }
+            (void) re2::RE2::Replace(&s, *(&re), r);
         }
+        return rres(env, s);
     }
     else
     {

--- a/src/re2.erl
+++ b/src/re2.erl
@@ -51,13 +51,14 @@ load_nif() ->
 -type value_spec_type() :: 'index' | 'binary'.
 -type value_id()        :: non_neg_integer() | string() | atom().
 -type match_result()    :: 'match' | 'nomatch' | {'match', list()}
-                         | {'error', any()}.
+                         | {'error', atom()}.
 
+-type re2error()        :: {atom(), string(), string()}.
 -type compile_option()  :: 'caseless' | {'max_mem', non_neg_integer()}.
--type compile_result()  :: {'ok', compiled_pattern()} | {'error', any()}.
+-type compile_result()  :: {'ok', compiled_pattern()} | {'error', re2error()}.
 
 -type replace_option()  :: 'global'.
--type replace_result()  :: binary() | {'error', any()} | 'error'.
+-type replace_result()  :: binary() | {'error', atom()} | 'error'.
 
 -spec compile(Pattern::uncompiled_pattern()) -> compile_result().
 compile(_) ->

--- a/src/re2.erl
+++ b/src/re2.erl
@@ -15,9 +15,13 @@
          replace/3,
          replace/4]).
 
--export_type([compile_option/0,
+-export_type([
+              uncompiled_regex/0,
+              compiled_regex/0,
+              compile_option/0,
               match_option/0,
-              replace_option/0]).
+              replace_option/0
+             ]).
 
 -on_load(load_nif/0).
 
@@ -37,10 +41,10 @@ load_nif() ->
     erlang:load_nif(filename:join(PrivDir, "re2_nif"), 0).
 
 
--type uncompiled_pattern() :: iodata().
--opaque compiled_pattern() :: binary().
--type input() :: iodata().
--type pattern() :: uncompiled_pattern() | compiled_pattern().
+-type uncompiled_regex() :: iodata().
+-opaque compiled_regex() :: binary().
+-type subject() :: iodata().
+-type regex() :: uncompiled_regex() | compiled_regex().
 -type replacement() :: iodata().
 
 -type match_option() :: 'caseless' | {'offset', non_neg_integer()}
@@ -55,36 +59,32 @@ load_nif() ->
 
 -type re2error() :: {atom(), string(), string()}.
 -type compile_option() :: 'caseless' | {'max_mem', non_neg_integer()}.
--type compile_result() :: {'ok', compiled_pattern()} | {'error', re2error()}.
+-type compile_result() :: {'ok', compiled_regex()} | {'error', re2error()}.
 
 -type replace_option() :: 'global'.
 -type replace_result() :: binary() | {'error', atom()} | 'error'.
 
--spec compile(Pattern::uncompiled_pattern()) -> compile_result().
+-spec compile(uncompiled_regex()) -> compile_result().
 compile(_) ->
     ?nif_stub.
 
--spec compile(Pattern::uncompiled_pattern(),
-              Options::[compile_option()]) -> compile_result().
+-spec compile(uncompiled_regex(), [compile_option()]) -> compile_result().
 compile(_,_) ->
     ?nif_stub.
 
--spec match(Input::input(), Pattern::pattern()) -> match_result().
+-spec match(subject(), regex()) -> match_result().
 match(_,_) ->
     ?nif_stub.
 
--spec match(Input::input(), Pattern::pattern(),
-            Options::[match_option()]) -> match_result().
+-spec match(subject(), regex(), [match_option()]) -> match_result().
 match(_,_,_) ->
     ?nif_stub.
 
--spec replace(Input::input(), Pattern::pattern(),
-              Replacement::replacement()) -> replace_result().
+-spec replace(subject(), regex(), replacement()) -> replace_result().
 replace(_,_,_) ->
     ?nif_stub.
 
--spec replace(Input::input(), Pattern::pattern(),
-              Replacement::replacement(),
-              Options::[replace_option()]) -> replace_result().
+-spec replace(subject(), regex(), replacement(),
+              [replace_option()]) -> replace_result().
 replace(_,_,_,_) ->
     ?nif_stub.

--- a/src/re2.erl
+++ b/src/re2.erl
@@ -68,7 +68,7 @@ load_nif() ->
 -type compile_result() :: {'ok', compiled_regex()} | compile_error().
 
 -type replace_option() :: 'global'.
--type replace_result() :: binary() | {'error', atom()} | 'error'.
+-type replace_result() :: binary() | {'error', atom()}.
 
 -spec compile(uncompiled_regex()) -> compile_result().
 compile(_) ->

--- a/src/re2.erl
+++ b/src/re2.erl
@@ -42,13 +42,13 @@ load_nif() ->
 
 
 -type uncompiled_regex() :: iodata().
-%% compile_regex/0 is an opaque datatype containing a compiled regex
+-opaque compiled_regex() :: any().
+%% compiled_regex/0 is an opaque datatype containing a compiled regex
 %% created by enif_make_resource(). Resources are totally opaque,
 %% which means the actual type is undefined. In the current Erlang vm
-%% they behave like empty binaries (<<>>) in Erlang land, but that
-%% could change in future releases. Therefore, make no assumptions,
-%% and always treat it as an opaque datatype.
--opaque compiled_regex() :: binary().
+%% they behave like empty (&lt;&lt;&gt;&gt;) binaries on the Erlang
+%% side, but that could change in future releases. Therefore, make no
+%% assumptions, and always treat it as an opaque datatype.
 -type subject() :: iodata().
 -type regex() :: uncompiled_regex() | compiled_regex().
 -type replacement() :: iodata().
@@ -63,9 +63,9 @@ load_nif() ->
 -type match_result() :: 'match' | 'nomatch' | {'match', list()}
                       | {'error', atom()}.
 
--type re2error() :: {atom(), string(), string()}.
+-type compile_error() :: {'error', {atom(), string(), string()}}.
 -type compile_option() :: 'caseless' | {'max_mem', non_neg_integer()}.
--type compile_result() :: {'ok', compiled_regex()} | {'error', re2error()}.
+-type compile_result() :: {'ok', compiled_regex()} | compile_error().
 
 -type replace_option() :: 'global'.
 -type replace_result() :: binary() | {'error', atom()} | 'error'.

--- a/src/re2.erl
+++ b/src/re2.erl
@@ -57,7 +57,7 @@ load_nif() ->
 -type compile_result()  :: {'ok', compiled_pattern()} | {'error', any()}.
 
 -type replace_option()  :: 'global'.
--type replace_result()  :: iodata() | {'error', any()} | 'error'.
+-type replace_result()  :: binary() | {'error', any()} | 'error'.
 
 -spec compile(Pattern::uncompiled_pattern()) -> compile_result().
 compile(_) ->

--- a/src/re2.erl
+++ b/src/re2.erl
@@ -39,26 +39,26 @@ load_nif() ->
 
 -type uncompiled_pattern() :: iodata().
 -opaque compiled_pattern() :: binary().
--type input()           :: iodata().
--type pattern()         :: uncompiled_pattern() | compiled_pattern().
--type replacement()     :: iodata().
+-type input() :: iodata().
+-type pattern() :: uncompiled_pattern() | compiled_pattern().
+-type replacement() :: iodata().
 
--type match_option()    :: 'caseless' | {'offset', non_neg_integer()}
-                         | {'capture', value_spec()}
-                         | {'capture', value_spec(), value_spec_type()}.
--type value_spec()      :: 'all' | 'all_but_first' | 'first' | 'none'
-                         | [value_id()].
+-type match_option() :: 'caseless' | {'offset', non_neg_integer()}
+                      | {'capture', value_spec()}
+                      | {'capture', value_spec(), value_spec_type()}.
+-type value_spec() :: 'all' | 'all_but_first' | 'first' | 'none'
+                    | [value_id()].
 -type value_spec_type() :: 'index' | 'binary'.
--type value_id()        :: non_neg_integer() | string() | atom().
--type match_result()    :: 'match' | 'nomatch' | {'match', list()}
-                         | {'error', atom()}.
+-type value_id() :: non_neg_integer() | string() | atom().
+-type match_result() :: 'match' | 'nomatch' | {'match', list()}
+                      | {'error', atom()}.
 
--type re2error()        :: {atom(), string(), string()}.
--type compile_option()  :: 'caseless' | {'max_mem', non_neg_integer()}.
--type compile_result()  :: {'ok', compiled_pattern()} | {'error', re2error()}.
+-type re2error() :: {atom(), string(), string()}.
+-type compile_option() :: 'caseless' | {'max_mem', non_neg_integer()}.
+-type compile_result() :: {'ok', compiled_pattern()} | {'error', re2error()}.
 
--type replace_option()  :: 'global'.
--type replace_result()  :: binary() | {'error', atom()} | 'error'.
+-type replace_option() :: 'global'.
+-type replace_result() :: binary() | {'error', atom()} | 'error'.
 
 -spec compile(Pattern::uncompiled_pattern()) -> compile_result().
 compile(_) ->

--- a/src/re2.erl
+++ b/src/re2.erl
@@ -1,4 +1,4 @@
-%% Copyright 2010-2011 Tuncer Ayaz. All Rights Reserved.
+%% Copyright 2010-2014 Tuncer Ayaz. All Rights Reserved.
 %% Use of this source code is governed by a BSD-style
 %% license that can be found in the LICENSE file.
 %%

--- a/src/re2.erl
+++ b/src/re2.erl
@@ -42,6 +42,12 @@ load_nif() ->
 
 
 -type uncompiled_regex() :: iodata().
+%% compile_regex/0 is an opaque datatype containing a compiled regex
+%% created by enif_make_resource(). Resources are totally opaque,
+%% which means the actual type is undefined. In the current Erlang vm
+%% they behave like empty binaries (<<>>) in Erlang land, but that
+%% could change in future releases. Therefore, make no assumptions,
+%% and always treat it as an opaque datatype.
 -opaque compiled_regex() :: binary().
 -type subject() :: iodata().
 -type regex() :: uncompiled_regex() | compiled_regex().

--- a/test/re2_tests.erl
+++ b/test/re2_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2010-2011 Tuncer Ayaz. All Rights Reserved.
+%% Copyright 2010-2014 Tuncer Ayaz. All Rights Reserved.
 %% Use of this source code is governed by a BSD-style
 %% license that can be found in the LICENSE file.
 

--- a/test/re2_tests.erl
+++ b/test/re2_tests.erl
@@ -18,13 +18,13 @@ replace_test() ->
     ?assertEqual(<<"heLo worLd">>,
                  re2:replace("hello world","l+","L",[global])),
     ?assertEqual(<<"heLo world">>, re2:replace("hello world","l+","L")),
-    ?assertEqual(error, re2:replace("hello world","k+","L")),
+    ?assertEqual(<<"hello world">>, re2:replace("hello world","k+","L")),
     {ok, RegExR0} = re2:compile("l+"),
     ?assertEqual(<<"heLo worLd">>,
                  re2:replace("hello world",RegExR0,"L",[global])),
     ?assertEqual(<<"heLo world">>, re2:replace("hello world",RegExR0,"L")),
     {ok, RegExR1} = re2:compile("k+"),
-    ?assertEqual(error, re2:replace("hello world",RegExR1,"L")),
+    ?assertEqual(<<"hello world">>, re2:replace("hello world",RegExR1,"L")),
     ?assertMatch({'EXIT', {badarg,_}},
                  (catch re2:replace("hello world","l+","L",[unknown]))).
 


### PR DESCRIPTION
You may or may not want to take the "Return original string" change. It makes re2:replace better match re:replace's behavior, but it is an API change and I can also see an argument for the current behavior.

The Makefile change I made because "make test" was failing for me after my re2:replace changes because rebar was picking up a system version of the re2 library instead of this one. It introduces some GNU-makeisms.