### PR TITLE
Add --std=c++11 to CXXFLAGS since re2 now depends on it

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -14,7 +14,7 @@ case "$1" in
 
     (test -d re2 || git clone https://code.googlesource.com/re2)
 
-    CXXFLAGS="-Wall -O3 -fPIC -pthread -m$ERLANG_ARCH"
+    CXXFLAGS="-Wall -O3 -fPIC -pthread --std=c++11 -m$ERLANG_ARCH"
     CXX="${CXX:-c++} -m$ERLANG_ARCH"
     which gmake 1>/dev/null 2>/dev/null && MAKE=gmake
     MAKE=${MAKE:-make}


### PR DESCRIPTION
Latest master of re2 build fails because of this commit:

https://code.googlesource.com/re2/+/cd505f4597d4022902b25bd036de29478e22d481