### PR TITLE
Add -std=c++11 to DRV_CFLAGS in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {port_specs, [{"priv/re2_nif.so",["c_src/re2_nif.cpp"]}]}.
 
-{port_env, [{"DRV_CFLAGS",  "$DRV_CFLAGS -O3 -Wall -Wextra -I c_src/re2"},
+{port_env, [{"DRV_CFLAGS",  "$DRV_CFLAGS -O3 -Wall -Wextra -std=c++11 -I c_src/re2"},
             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/re2/obj/libre2.a"},
 
             %% Make sure to link -lstdc++ on Linux, FreeBSD, or Solaris


### PR DESCRIPTION
We needed this to get the NIF to compile.