### PR TITLE
Update libre2 detection to support osx

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -8,3 +8,4 @@ Masahito Ikuta
 Steve Vinoski
 Janin Kolenc
 Dan Checkoway
+Mathieu D'Amours

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -50,7 +50,7 @@ LibCPP = "c++".
 LibStdCPP = "stdc++".
 
 MaybeUseLibCPP = fun() ->
-                         case FindLibByWC("libc++*.so", LibCPP, LibStdCPP) of
+                         case FindLibByWC("libc++*.{so,dylib}", LibCPP, LibStdCPP) of
                              {_LibDir, LibCPP} -> LibCPP;
                              LibStdCPP -> LibStdCPP
                          end
@@ -89,7 +89,7 @@ FindRe2 = fun(SysLib, LocalLib) ->
                   %% use of re2, but that would needlessly complicate the build
                   %% process due to the requirement of caching configure
                   %% results.
-                  Lib = FindLibByWC("libre2.so", SysLib, LocalLib),
+                  Lib = FindLibByWC("libre2.{so,dylib}", SysLib, LocalLib),
                   IncDir = Re2IncDir(),
                   case {IncDir, Lib} of
                       %% re2.h not found, and even though libre2 might


### PR DESCRIPTION
I still couldn't compile re2 under rebar3 locally (complained it couldn't find `<re2/re2.h>`, it seemed the build script wasn't called at all).

To circumvent I tried using system-provided libre2 by installing it using homebrew and it still failed because it couldn't find `libre2.so`, but that's because `.so` is not the file extension under osx (and possibly under other *BSD systems, though I'm not sure).