### PR TITLE
Set less strict permissions on the rebar executable

### DIFF
--- a/support/getrebar
+++ b/support/getrebar
@@ -51,7 +51,7 @@ obtain(bin) ->
                 ok ->
                     case is_escript(Rebar) of
                         true ->
-                            ok = file:change_mode(Rebar, 8#700),
+                            ok = file:change_mode(Rebar, 8#755),
                             {ok, Rebar};
                         false -> false
                     end;


### PR DESCRIPTION
This mode 0700 makes Travis sad in our build environment, where the getrebar may be executed inside a build container and somehow that permission makes a subsequent docker build command fail with `Error checking context: 'no permission to read from '/home/travis/build/PagerDuty/event-rule-engine/deps/re2/support/rebar''.`. 

I think that mode 0700 offers no security here and 0755 should prevent such little issues.