### PR TITLE
Allow for RE2 repo url to be overriden by env var

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,7 +78,7 @@ on the system, you can set the env var =SYSTEM_RE2=1=. If you do that
 and the library can not be found, it will fall back to a local copy
 (=c_src/re2=). Also, if you want to override the RE2 version that is
 fetched and built, when not using system RE2, you can do so by setting
-=RE2_REV= to a git rev.   By default, the re2 upstream code will be
+=RE2_REV= to a git rev.   By default, the RE2 upstream code will be
 fetched from =https://github.com/google/re2= or in some cases
 =https://code.googlesource.com/re2=, however, if you need to fetch the
 upstream source from some other git repository, you can do so by

--- a/README.org
+++ b/README.org
@@ -78,7 +78,11 @@ on the system, you can set the env var =SYSTEM_RE2=1=. If you do that
 and the library can not be found, it will fall back to a local copy
 (=c_src/re2=). Also, if you want to override the RE2 version that is
 fetched and built, when not using system RE2, you can do so by setting
-=RE2_REV= to a git rev.
+=RE2_REV= to a git rev.   By default, the re2 upstream code will be
+fetched from =https://github.com/google/re2= or in some cases
+=https://code.googlesource.com/re2=, however, if you need to fetch the
+upstream source from some other git repository, you can do so by
+setting the =RE2_URL= to a different git url.
 
 Unless otherwise noted, the [[https://github.com/google/re2][RE2]]
 source files are distributed under the BSD-style license found in

--- a/README.org
+++ b/README.org
@@ -78,11 +78,13 @@ on the system, you can set the env var =SYSTEM_RE2=1=. If you do that
 and the library can not be found, it will fall back to a local copy
 (=c_src/re2=). Also, if you want to override the RE2 version that is
 fetched and built, when not using system RE2, you can do so by setting
-=RE2_REV= to a git rev.   By default, the RE2 upstream code will be
-fetched from =https://github.com/google/re2= or in some cases
-=https://code.googlesource.com/re2=, however, if you need to fetch the
-upstream source from some other git repository, you can do so by
-setting the =RE2_URL= to a different git url.
+=RE2_REV= to a git rev.
+
+By default, if the re2 nif project was cloned from github, then we clone
+RE2 from =https://github.com/google/re2= (assuming that host is accessible).
+If not, we clone from =https://code.googlesource.com/re2=.
+However, if you need to fetch the upstream source from some other git
+repository, you can do so by setting the =RE2_URL= to a different git url.
 
 Unless otherwise noted, the [[https://github.com/google/re2][RE2]]
 source files are distributed under the BSD-style license found in

--- a/README.org
+++ b/README.org
@@ -80,10 +80,9 @@ and the library can not be found, it will fall back to a local copy
 fetched and built, when not using system RE2, you can do so by setting
 =RE2_REV= to a git rev.
 
-By default, RE2 is fetched from =https://github.com/google/re2=
-or in some cases =https://code.googlesource.com/re2=.
-If you need to fetch the upstream source from some other git
-repository, you can do so by setting the =RE2_URL= environment
+By default, RE2 upstream source is fetched from the Google remote.
+If for some reason you need to fetch the upstream source from some
+other git repository, you can do so by setting the =RE2_URL= environment
 variable to a different git url.
 
 Unless otherwise noted, the [[https://github.com/google/re2][RE2]]

--- a/README.org
+++ b/README.org
@@ -80,11 +80,11 @@ and the library can not be found, it will fall back to a local copy
 fetched and built, when not using system RE2, you can do so by setting
 =RE2_REV= to a git rev.
 
-By default, if the re2 nif project was cloned from github, then we clone
-RE2 from =https://github.com/google/re2= (assuming that host is accessible).
-If not, we clone from =https://code.googlesource.com/re2=.
-However, if you need to fetch the upstream source from some other git
-repository, you can do so by setting the =RE2_URL= to a different git url.
+By default, RE2 is fetched from =https://github.com/google/re2=
+or in some cases =https://code.googlesource.com/re2=.
+If you need to fetch the upstream source from some other git
+repository, you can do so by setting the =RE2_URL= environment
+variable to a different git url.
 
 Unless otherwise noted, the [[https://github.com/google/re2][RE2]]
 source files are distributed under the BSD-style license found in

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -20,13 +20,13 @@ case "$1" in
     RE2_REV=${RE2_REV:-2018-02-01}
     case $(git config --get remote.origin.url) in
         git@github.com*|https://github.com*|git://github.com*)
-            MAYBE_RE2_URL=https://github.com/google/re2
+            DEFAULT_RE2_URL=https://github.com/google/re2
             ;;
         *)
-            MAYBE_RE2_URL=https://code.googlesource.com/re2
+            DEFAULT_RE2_URL=https://code.googlesource.com/re2
             ;;
     esac
-    RE2_URL=${RE2_URL:-$MAYBE_RE2_URL}
+    RE2_URL=${RE2_URL:-$DEFAULT_RE2_URL}
     test -d re2 || git clone $RE2_URL re2
     (cd re2 && git fetch --all && git checkout $RE2_REV)
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -20,13 +20,13 @@ case "$1" in
     RE2_REV=${RE2_REV:-2018-02-01}
     case $(git config --get remote.origin.url) in
         git@github.com*|https://github.com*|git://github.com*)
-            DEFAULT_RE2_URL=https://github.com/google/re2
+            RE2_DEFAULT_URL=https://github.com/google/re2
             ;;
         *)
-            DEFAULT_RE2_URL=https://code.googlesource.com/re2
+            RE2_DEFAULT_URL=https://code.googlesource.com/re2
             ;;
     esac
-    RE2_URL=${RE2_URL:-$DEFAULT_RE2_URL}
+    RE2_URL=${RE2_URL:-$RE2_DEFAULT_URL}
     test -d re2 || git clone $RE2_URL re2
     (cd re2 && git fetch --all && git checkout $RE2_REV)
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -20,13 +20,14 @@ case "$1" in
     RE2_REV=${RE2_REV:-2018-02-01}
     case $(git config --get remote.origin.url) in
         git@github.com*|https://github.com*|git://github.com*)
-            RE2_URL=https://github.com/google/re2
+            MAYBE_RE2_URL=https://github.com/google/re2
             ;;
         *)
-            RE2_URL=https://code.googlesource.com/re2
+            MAYBE_RE2_URL=https://code.googlesource.com/re2
             ;;
     esac
-    test -d re2 || git clone $RE2_URL
+    RE2_URL=${RE2_URL:-$MAYBE_RE2_URL}
+    test -d re2 || git clone $RE2_URL re2
     (cd re2 && git fetch --all && git checkout $RE2_REV)
 
     CXXFLAGS="-Wall -O3 -fPIC -pthread -std=c++11 -m$ERLANG_ARCH"


### PR DESCRIPTION
We tend to mirror code into our local git for builds, so this allows us
to specify our mirrored url.  As the mirror might have a different name
I also specify the name of the checkout directory so that the build will
continue.