### PR TITLE
dev/l.sh: use rebar3 path cmd

### DIFF
--- a/dev/l.sh
+++ b/dev/l.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
 /usr/bin/time erl \
-    -pa _build/debug/lib/re2/ebin \
+    -pa $(rebar3 as debug path --ebin) \
     -noinput \
     -eval "re2:l($1), init:stop()."


### PR DESCRIPTION
Instead of hard-coding ebin path, rely on rebar3's path command.